### PR TITLE
Transfer configuration into container as parameters.

### DIFF
--- a/src/Surfnet/MessageBirdApiClientBundle/DependencyInjection/SurfnetMessageBirdApiClientExtension.php
+++ b/src/Surfnet/MessageBirdApiClientBundle/DependencyInjection/SurfnetMessageBirdApiClientExtension.php
@@ -40,7 +40,7 @@ class SurfnetMessageBirdApiClientExtension extends Extension
 
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../Resources/config')
+            new FileLocator(__DIR__ . '/../Resources/config')
         );
         $loader->load('services.yml');
     }


### PR DESCRIPTION
Configuration was not available in service definitions.
