### PR TITLE
Ignore cache.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/cache.properties


### PR DESCRIPTION
Ensures /cache.properties isn't added to Git by RMT in future releases.

See https://github.com/SURFnet/messagebird-api-client-bundle/pull/7.
